### PR TITLE
[whitelist.js] Add support for completely ignoring files

### DIFF
--- a/lib/check/whitelist.js
+++ b/lib/check/whitelist.js
@@ -28,5 +28,14 @@ function whitelist(ctx) {
           }
       }
     }
+    for (var whitelistedFile of jsonData.files) {
+      // Match on a substring of the reference with the whitelisted file
+      if (reference.includes(whitelistedFile)) {
+        console.warn("[Warning] Ignoring file in whitelisted link to: '%s'", whitelistedFile)
+        if (!delete references[reference]) {
+          console.error("Failed to delete the reference: '%s'", reference)
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
In addition to ignoring references within files, add also logic to
whitelist non existing files.

This is somewhat of a revert of 9a144fb, but decided to use a separate
field in the json to keep comptatibility.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>