### PR TITLE
chore: made reference to slugger commit more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "index.js"
   ],
   "dependencies": {
-    "github-slugger": "https://github.com/oleorhagen/github-slugger#grav-slug",
+    "github-slugger": "https://github.com/oleorhagen/github-slugger#5acdd7653301b42ac3e9543b9ea7717f558a139a",
     "hosted-git-info": "^3.0.0",
     "mdast-util-to-string": "^1.0.0",
     "propose": "0.0.5",


### PR DESCRIPTION
- this is to help seeing package age

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>